### PR TITLE
Change Jack-O abbreviation to 'JC'

### DIFF
--- a/src/website.rs
+++ b/src/website.rs
@@ -32,7 +32,7 @@ pub const CHAR_NAMES: &[(&str, &str)] = &[
     ("AN", "Anji"),
     ("IN", "I-No"),
     ("GO", "Goldlewis"),
-    ("JA", "Jack-O'"),
+    ("JC", "Jack-O'"),
     ("HA", "Happy Chaos"),
 ];
 


### PR DESCRIPTION
The abbreviation 'JA' is used for Jam on [dustloop](https://www.dustloop.com/wiki/index.php?title=GGXRD-R2/Character_List), with 'JC' being used for [Jack-O even in GGST](https://www.dustloop.com/wiki/index.php?title=GGST/Character_List).
The abbreviations used in this website should probably follow the precedence set by dustloop.