### PR TITLE
feat: Update ggst-api-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,15 +14,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,13 +549,14 @@ dependencies = [
 [[package]]
 name = "ggst-api"
 version = "0.2.0"
-source = "git+https://github.com/halvnykterist/ggst-api-rs#7cb1eaf666d772e4e39284106dc4f97785e08447"
+source = "git+https://github.com/xynxynxyn/ggst-api-rs#7c995bad47c6c8b4c577da37051316529b0c338f"
 dependencies = [
+ "bytes",
  "chrono",
  "derivative",
- "lazy_static",
- "regex",
  "reqwest",
+ "rmp-serde",
+ "serde",
  "tokio",
 ]
 
@@ -1430,8 +1422,6 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 
@@ -1493,6 +1483,27 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f55e5fa1446c4d5dd1f5daeed2a4fe193071771a2636274d0d7a3b082aa7ad6"
+dependencies = [
+ "byteorder",
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3eedffbfcc6a428f230c04baf8f59bd73c1781361e4286111fe900849aaddaf"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ glicko2 = "0.3.1"
 rocket = { version = "0.5.0-rc.1", features = ["json"] }
 rocket_sync_db_pools = { version = "0.1.0-rc.1", default-features = false, features = ["sqlite_pool"] }
 rocket_dyn_templates = { version = "0.1.0-rc.1", default-features = false, features = ["handlebars"] }
-ggst-api = { git = "https://github.com/halvnykterist/ggst-api-rs" }
+ggst-api = { git = "https://github.com/xynxynxyn/ggst-api-rs" }
 tokio = { version = "1", features=["full"] }
 rusqlite = { version = "0.25", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Includes https://github.com/xynxynxyn/ggst-api-rs/pull/5 which use a
real messagepack encoder/decoder to communicate with the replay API
which picks up some replays which were missed by the older decoder.

Also grabs some more information from the response, though those are not
exposed in the public API at the moment.

Since this parser is a bit more strict it is possible that some new
errors occurs, though I have not seen any in my testing with the merged
version.