### PR TITLE
perf: Add indicies to speedup match history lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
 static/sass/
 ratings.sqlite
+*.sqlite-journal
 output.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +175,15 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "cast"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
+dependencies = [
+ "rustc_version 0.4.0",
+]
 
 [[package]]
 name = "cc"
@@ -193,6 +214,17 @@ dependencies = [
  "num-traits",
  "time 0.1.43",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "bitflags",
+ "textwrap",
+ "unicode-width",
 ]
 
 [[package]]
@@ -227,6 +259,111 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "criterion"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "futures",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+dependencies = [
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "derivative"
@@ -599,6 +736,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "handlebars"
 version = "3.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +926,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,6 +1053,15 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1110,6 +1271,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,6 +1431,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
+name = "plotters"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,6 +1574,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "criterion",
  "fxhash",
  "ggst-api",
  "glicko2",
@@ -1386,6 +1582,7 @@ dependencies = [
  "lazy_static",
  "log",
  "num-format",
+ "reqwest",
  "rocket",
  "rocket_dyn_templates",
  "rocket_sync_db_pools",
@@ -1393,6 +1590,31 @@ dependencies = [
  "serde",
  "simplelog",
  "tokio",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
 ]
 
 [[package]]
@@ -1658,7 +1880,16 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.7",
 ]
 
 [[package]]
@@ -1746,6 +1977,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
+
+[[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,6 +1995,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -1912,7 +2159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
 dependencies = [
  "discard",
- "rustc_version",
+ "rustc_version 0.2.3",
  "stdweb-derive",
  "stdweb-internal-macros",
  "stdweb-internal-runtime",
@@ -1989,6 +2236,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,6 +2299,16 @@ dependencies = [
  "quote",
  "standback",
  "syn",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2253,6 +2519,12 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+
+[[package]]
 name = "arrayvec"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,6 +1377,7 @@ dependencies = [
 name = "rating-update"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "fxhash",
  "ggst-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,6 +1575,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "criterion",
+ "futures",
  "fxhash",
  "ggst-api",
  "glicko2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ num-format = "0.4"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["async_tokio"] }
+futures = "0.3"
 reqwest = "0.11"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1"
 glicko2 = "0.3.1"
 rocket = { version = "0.5.0-rc.1", features = ["json"] }
 rocket_sync_db_pools = { version = "0.1.0-rc.1", default-features = false, features = ["sqlite_pool"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,15 @@ simplelog = "0.9"
 log = "0.4"
 fxhash = "0.2"
 num-format = "0.4"
+
+[dev-dependencies]
+criterion = { version = "0.3", features = ["async_tokio"] }
+reqwest = "0.11"
+
+[[bench]]
+name = "bench"
+harness = false
+
+
+[profile.bench]
+debug = 1

--- a/README.md
+++ b/README.md
@@ -3,3 +3,18 @@ Ratings for Guilty Gear: Strive
 
 ## Customizing
 Download [Bulma's](https://bulma.io/) sass source files and place the contents in /static/sass. Use the sass executable via npm to generate styles **.css** from styles. **scss**.
+
+
+## Setting up a local database for development
+
+To setup a database with some data you can run the following commands.
+
+```bash
+cargo run -- init # Setup the tables and indices of the database
+cargo run -- pull # Pull down replays from the GGST API
+cargo run -- update # Update the ratings
+```
+
+Once the database is setup you can start a local server that is accessible on `localhost`
+with `cargo run`. By default the server will continuously pull down new replays and update the rankings. If you do not
+want this behaviour you may run `cargo run -- nothoughts` instead to only start the website.

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,4 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
+use futures::prelude::*;
 
 fn load_player(c: &mut Criterion) {
     let runtime = tokio::runtime::Runtime::new().unwrap();
@@ -8,11 +9,35 @@ fn load_player(c: &mut Criterion) {
 
     c.bench_function("load_player", |b| {
 
-        b.to_async(&runtime).iter(|| async {
-            let response = http_client.get("http://localhost/player/2EC4D20AC79D536/KY").send().await.unwrap();
+        // Find a number of players to run the benchmark on
+        let players = {
+            let db_connection = rusqlite::Connection::open(rating_update::rater::DB_NAME).unwrap();
+            let mut stmt = db_connection
+                .prepare("SELECT id, char_id FROM ranking_global LIMIT 50")
+                .unwrap();
 
-            assert_eq!(response.status(), reqwest::StatusCode::OK);
-            response.bytes().await.unwrap();
+            let mut rows = stmt.query([]).unwrap();
+            let mut players = Vec::<(i64, usize)>::new();
+            while let Some(row) = rows.next().unwrap() {
+                players.push((row.get(0).unwrap(), row.get(1).unwrap()));
+            }
+
+            assert_eq!(players.len(), 50);
+            players
+        };
+
+        b.to_async(&runtime).iter(|| async {
+
+            let http_client = &http_client;
+            futures::stream::iter(&players)
+                .map(|&(id, char_id)| async move {
+                    let response = http_client.get(format!("http://localhost/player/{:X}/{}", id, rating_update::website::CHAR_NAMES[char_id].0)).send().await.unwrap();
+
+                    assert_eq!(response.status(), reqwest::StatusCode::OK);
+                    response.bytes().await.unwrap();
+                })
+                .buffer_unordered(10)
+                .for_each(|()| async {}).await;
         });
     });
 }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,21 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn load_player(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let http_client = reqwest::Client::new();
+
+    runtime.block_on(async { tokio::spawn(rating_update::website::run()); });
+
+    c.bench_function("load_player", |b| {
+
+        b.to_async(&runtime).iter(|| async {
+            let response = http_client.get("http://localhost/player/2EC4D20AC79D536/KY").send().await.unwrap();
+
+            assert_eq!(response.status(), reqwest::StatusCode::OK);
+            response.bytes().await.unwrap();
+        });
+    });
+}
+
+criterion_group!(bench, load_player);
+criterion_main!(bench);

--- a/init.sql
+++ b/init.sql
@@ -14,6 +14,16 @@ CREATE TABLE games (
 CREATE INDEX games_char_a ON games(char_a);
 CREATE INDEX games_char_b ON games(char_b);
 
+-- Indices for speeding up player character match history lookup
+CREATE INDEX games_id_char_a ON games (
+	id_a,
+	char_a
+)
+CREATE INDEX games_id_char_b ON games (
+	id_b,
+	char_b
+)
+
 CREATE TABLE game_ratings (
     timestamp INTEGER NOT NULL,
     id_a INTEGER NOT NULL,

--- a/src/api.rs
+++ b/src/api.rs
@@ -2,7 +2,7 @@ use chrono::{Duration, NaiveDateTime, Utc};
 use fxhash::FxHashMap;
 use glicko2::{Glicko2Rating, GlickoRating};
 use rocket::serde::{json::Json, Serialize};
-use rusqlite::{named_params, params, OptionalExtension};
+use rusqlite::{named_params, params, Connection, OptionalExtension};
 
 use crate::{
     rater::{self, RatedPlayer},
@@ -172,7 +172,7 @@ pub async fn top_all_inner(conn: &RatingsDbConn) -> Vec<RankingPlayer> {
         let mut stmt = c
             .prepare(
                 "SELECT player_ratings.id as id, char_id, wins, losses, value, deviation, volatility, name, vip_status, cheater_status
-                 FROM ranking_global 
+                 FROM ranking_global
                  NATURAL JOIN player_ratings
                  NATURAL JOIN players
                  LEFT JOIN vip_status ON vip_status.id = player_ratings.id
@@ -238,7 +238,7 @@ pub async fn search_inner(
         let mut stmt = c
             .prepare(
                 "SELECT * FROM
-                    player_names 
+                    player_names
                     NATURAL JOIN player_ratings
                     LEFT JOIN vip_status ON vip_status.id = player_names.id
                     LEFT JOIN cheater_status ON cheater_status.id = player_names.id
@@ -297,7 +297,7 @@ pub async fn top_char_inner(conn: &RatingsDbConn, char_id: i64) -> Vec<RankingPl
         let mut stmt = c
             .prepare(
                 "SELECT player_ratings.id as id, char_id, wins, losses, value, deviation, volatility, name, vip_status, cheater_status
-                 FROM ranking_character 
+                 FROM ranking_character
                  NATURAL JOIN player_ratings
                  NATURAL JOIN players
                  LEFT JOIN vip_status ON vip_status.id = player_ratings.id
@@ -447,8 +447,8 @@ pub async fn get_player_highest_rated_character(conn: &RatingsDbConn, id: i64) -
     conn.run(move |conn| {
         conn.query_row(
             "SELECT char_id
-        FROM player_ratings 
-        WHERE id=? 
+        FROM player_ratings
+        WHERE id=?
         ORDER BY value - 3.0  * deviation DESC
         LIMIT 1",
             params![id],
@@ -478,7 +478,7 @@ pub async fn get_player_data_char(
         {
             let (name, vip_status, cheater_status): (String, Option<String>, Option<String>) = conn
                 .query_row(
-                    "SELECT name, vip_status, cheater_status FROM players 
+                    "SELECT name, vip_status, cheater_status FROM players
                         LEFT JOIN vip_status ON vip_status.id = players.id
                         LEFT JOIN cheater_status ON cheater_status.id = players.id
                            WHERE players.id=?
@@ -492,509 +492,11 @@ pub async fn get_player_data_char(
                 name,
                 website::CHAR_NAMES[char_id as usize].0
             );
-            let other_names = {
-                let mut stmt = conn
-                    .prepare("SELECT name FROM player_names WHERE id=?")
-                    .unwrap();
-                let mut rows = stmt.query(params![id]).unwrap();
-                let mut other_names = Vec::new();
-                while let Some(row) = rows.next().unwrap() {
-                    let other_name: String = row.get(0).unwrap();
-                    if other_name != name && !other_names.contains(&other_name) {
-                        other_names.push(other_name);
-                    }
-                }
+            let other_names = get_player_other_names(conn, id, &name);
 
-                other_names
-            };
+            let other_characters = get_player_other_characters(conn, id);
 
-            let other_characters = {
-                let mut stmt = conn
-                    .prepare(
-                        "SELECT
-                        char_id, wins, losses, value, deviation
-                        FROM player_ratings
-                        WHERE id=?",
-                    )
-                    .unwrap();
-
-                let mut other_characters = Vec::new();
-
-                let mut rows = stmt.query(params![id]).unwrap();
-
-                while let Some(row) = rows.next().unwrap() {
-                    let char_id: usize = row.get(0).unwrap();
-                    let game_count: i32 =
-                        row.get::<_, i32>(1).unwrap() + row.get::<_, i32>(2).unwrap();
-                    let rating: GlickoRating = Glicko2Rating {
-                        value: row.get(3).unwrap(),
-                        deviation: row.get(4).unwrap(),
-                        volatility: 0.0,
-                    }
-                    .into();
-
-                    let character_name = website::CHAR_NAMES[char_id].1.to_owned();
-                    let character_shortname = website::CHAR_NAMES[char_id].0.to_owned();
-                    other_characters.push(OtherPlayerCharacter {
-                        character_name,
-                        character_shortname,
-                        game_count,
-                        rating_value: rating.value.round(),
-                        rating_deviation: (rating.deviation * 2.0).round(),
-                    });
-                }
-
-                other_characters
-            };
-
-            let character_data = {
-                let (wins, losses, value, deviation, global_rank, character_rank) = conn
-                    .query_row(
-                        "SELECT wins, losses, value, deviation, global_rank, character_rank
-                        FROM player_ratings
-                        LEFT JOIN ranking_global ON
-                            ranking_global.id = player_ratings.id AND
-                            ranking_global.char_id = player_ratings.char_id
-                        LEFT JOIN ranking_character ON
-                            ranking_character.id = player_ratings.id AND
-                            ranking_character.char_id = player_ratings.char_id
-                        WHERE player_ratings.id=? AND player_ratings.char_id=?",
-                        params![id, char_id],
-                        |row| {
-                            Ok((
-                                row.get::<_, i32>(0).unwrap(),
-                                row.get::<_, i32>(1).unwrap(),
-                                row.get::<_, f64>(2).unwrap(),
-                                row.get::<_, f64>(3).unwrap(),
-                                row.get::<_, Option<i32>>(4).unwrap(),
-                                row.get::<_, Option<i32>>(5).unwrap(),
-                            ))
-                        },
-                    )
-                    .unwrap();
-                {
-                    let character_name = website::CHAR_NAMES[char_id as usize].1.to_owned();
-
-                    let history = {
-                        let mut stmt = conn
-                            .prepare(
-                                "SELECT
-                                    timestamp,
-                                    value_a AS own_value,
-                                    deviation_a AS own_deviation,
-                                    game_floor,
-                                    name_b AS opponent_name,
-                                    id_b AS opponent_id,
-                                    char_b AS opponent_character,
-                                    value_b AS opponent_value,
-                                    deviation_b AS opponent_deviation,
-                                    winner,
-                                    vip_status,
-                                    cheater_status
-                                FROM games NATURAL JOIN game_ratings
-                                LEFT JOIN vip_status ON vip_status.id = games.id_b
-                                LEFT JOIN cheater_status ON cheater_status.id = games.id_b
-                                WHERE games.id_a= :id AND games.char_a = :char_id
-                            
-                                UNION
-
-                                SELECT
-                                    timestamp,
-                                    value_b AS own_value,
-                                    deviation_b AS own_deviation,
-                                    game_floor,
-                                    name_a AS opponent_name,
-                                    id_a AS opponent_id,
-                                    char_a AS opponent_character,
-                                    value_a AS opponent_value,
-                                    deviation_a AS opponent_deviation,
-                                    winner + 2  as winner,
-                                    vip_status,
-                                    cheater_status
-                                FROM games NATURAL JOIN game_ratings
-                                LEFT JOIN vip_status ON vip_status.id = games.id_a
-                                LEFT JOIN cheater_status ON cheater_status.id = games.id_a
-                                WHERE games.id_b = :id AND games.char_b = :char_id
-
-                                ORDER BY timestamp DESC LIMIT :game_count",
-                            )
-                            .unwrap();
-
-                        let mut rows = stmt
-                            .query(named_params! {
-                                ":id" : id,
-                                ":char_id": char_id,
-                                ":game_count":game_count,
-                            })
-                            .unwrap();
-                        let mut history = Vec::<PlayerSet>::new();
-                        while let Some(row) = rows.next().unwrap() {
-                            let timestamp: i64 = row.get("timestamp").unwrap();
-                            let own_value: f64 = row.get("own_value").unwrap();
-                            let own_deviation: f64 = row.get("own_deviation").unwrap();
-                            let floor: i64 = row.get("game_floor").unwrap();
-                            let opponent_name: String = row.get("opponent_name").unwrap();
-                            let opponent_id: i64 = row.get("opponent_id").unwrap();
-                            let opponent_character: i64 = row.get("opponent_character").unwrap();
-                            let opponent_value: f64 = row.get("opponent_value").unwrap();
-                            let opponent_deviation: f64 = row.get("opponent_deviation").unwrap();
-                            let winner: i64 = row.get("winner").unwrap();
-                            let opponent_vip: Option<String> = row.get("vip_status").unwrap();
-                            let opponent_cheater: Option<String> =
-                                row.get("cheater_status").unwrap();
-
-                            let own_rating: GlickoRating = Glicko2Rating {
-                                value: own_value,
-                                deviation: own_deviation,
-                                volatility: 0.0,
-                            }
-                            .into();
-
-                            let opponent_rating: GlickoRating = Glicko2Rating {
-                                value: opponent_value,
-                                deviation: opponent_deviation,
-                                volatility: 0.0,
-                            }
-                            .into();
-
-                            let (
-                                expected_outcome_min,
-                                expected_outcome,
-                                expected_outcome_max,
-                                expected_outcome_evaluation,
-                            ) = get_expected_outcomes(
-                                own_value,
-                                own_deviation,
-                                opponent_value,
-                                opponent_deviation,
-                            );
-
-                            if let Some(set) = history.last_mut().filter(|set| {
-                                set.opponent_id == format!("{:X}", opponent_id)
-                                    && set.opponent_character
-                                        == website::CHAR_NAMES[opponent_character as usize].1
-                                    && group_games
-                            }) {
-                                set.timestamp = format!(
-                                    "{}",
-                                    NaiveDateTime::from_timestamp(timestamp, 0)
-                                        .format("%Y-%m-%d %H:%M")
-                                );
-                                set.own_rating_value = own_rating.value.round();
-                                set.own_rating_deviation = (own_rating.deviation * 2.0).round();
-                                set.opponent_rating_value = opponent_rating.value.round();
-                                set.opponent_rating_deviation =
-                                    (opponent_rating.deviation * 2.0).round();
-
-                                set.expected_outcome = expected_outcome;
-                                set.expected_outcome_evaluation = expected_outcome_evaluation;
-                                set.expected_outcome_min = expected_outcome_min;
-                                set.expected_outcome_max = set.expected_outcome_max;
-
-                                match winner {
-                                    1 | 4 => set.result_wins += 1,
-                                    2 | 3 => set.result_losses += 1,
-                                    _ => panic!("Bad winner"),
-                                }
-
-                                set.result_percent = ((set.result_wins as f64
-                                    / (set.result_wins + set.result_losses) as f64)
-                                    * 100.0)
-                                    .round();
-                            } else {
-                                history.push(PlayerSet {
-                                    timestamp: format!(
-                                        "{}",
-                                        NaiveDateTime::from_timestamp(timestamp, 0)
-                                            .format("%Y-%m-%d %H:%M")
-                                    ),
-                                    own_rating_value: own_rating.value.round(),
-                                    own_rating_deviation: (own_rating.deviation * 2.0).round(),
-                                    floor: match floor {
-                                        99 => format!("Celestial"),
-                                        n => format!("Floor {}", n),
-                                    },
-                                    opponent_name: opponent_name,
-                                    opponent_vip,
-                                    opponent_cheater,
-                                    opponent_id: format!("{:X}", opponent_id),
-                                    opponent_character: website::CHAR_NAMES
-                                        [opponent_character as usize]
-                                        .1
-                                        .to_owned(),
-                                    opponent_character_short: website::CHAR_NAMES
-                                        [opponent_character as usize]
-                                        .0
-                                        .to_owned(),
-                                    opponent_rating_value: opponent_rating.value.round(),
-                                    opponent_rating_deviation: (opponent_rating.deviation * 2.0)
-                                        .round(),
-                                    expected_outcome,
-                                    expected_outcome_evaluation,
-                                    expected_outcome_min,
-                                    expected_outcome_max,
-                                    result_wins: match winner {
-                                        1 | 4 => 1,
-                                        _ => 0,
-                                    },
-                                    result_losses: match winner {
-                                        2 | 3 => 1,
-                                        _ => 0,
-                                    },
-                                    result_percent: match winner {
-                                        1 | 4 => 100.0,
-                                        _ => 0.0,
-                                    },
-                                });
-                            }
-                        }
-
-                        history
-                    };
-
-                    let recent_games = {
-                        let mut stmt = conn
-                            .prepare(
-                                "SELECT
-                            games.timestamp AS timestamp,
-                            game_floor,
-                            name_b AS opponent_name,
-                            games.id_b AS opponent_id,
-                            games.char_b AS opponent_character,
-                            winner,
-                            vip_status,
-                            cheater_status
-                        FROM games LEFT JOIN game_ratings 
-                        ON games.id_a = game_ratings.id_a 
-                            AND games.id_b = game_ratings.id_b 
-                            AND games.timestamp = game_ratings.timestamp
-                        LEFT JOIN vip_status ON vip_status.id = games.id_b
-                        LEFT JOIN cheater_status ON cheater_status.id = games.id_b
-                        WHERE games.id_a= :id 
-                            AND games.char_a = :char_id 
-                            AND game_ratings.id_a IS NULL
-                    
-                        UNION
-
-                        SELECT
-                            games.timestamp AS timestamp,
-                            game_floor,
-                            name_a AS opponent_name,
-                            games.id_a AS opponent_id,
-                            games.char_a AS opponent_character,
-                            winner + 2  as winner,
-                            vip_status,
-                            cheater_status
-                        FROM games LEFT JOIN game_ratings 
-                        ON games.id_a = game_ratings.id_a 
-                            AND games.id_b = game_ratings.id_b 
-                            AND games.timestamp = game_ratings.timestamp
-                        LEFT JOIN vip_status ON vip_status.id = games.id_a
-                        LEFT JOIN cheater_status ON cheater_status.id = games.id_a
-                        WHERE games.id_b= :id 
-                            AND games.char_b = :char_id 
-                            AND game_ratings.id_a IS NULL
-
-                        ORDER BY games.timestamp DESC",
-                            )
-                            .unwrap();
-
-                        let mut rows = stmt
-                            .query(named_params! {":id" : id, ":char_id": char_id})
-                            .unwrap();
-                        let mut recent_games = Vec::<PlayerSet>::new();
-                        while let Some(row) = rows.next().unwrap() {
-                            let timestamp: i64 = row.get("timestamp").unwrap();
-                            let floor: i64 = row.get("game_floor").unwrap();
-                            let opponent_name: String = row.get("opponent_name").unwrap();
-                            let opponent_id: i64 = row.get("opponent_id").unwrap();
-                            let opponent_character: i64 = row.get("opponent_character").unwrap();
-                            let winner: i64 = row.get("winner").unwrap();
-                            let opponent_vip: Option<String> = row.get("vip_status").unwrap();
-                            let opponent_cheater: Option<String> =
-                                row.get("cheater_status").unwrap();
-
-                            let own_rating: GlickoRating = Glicko2Rating {
-                                value: value,
-                                deviation: deviation,
-                                volatility: 0.0,
-                            }
-                            .into();
-
-                            let (opponent_value, opponent_deviation) = conn
-                                .query_row(
-                                    "SELECT value, deviation
-                                FROM player_ratings
-                                WHERE id=? AND char_id=?",
-                                    params![opponent_id, opponent_character],
-                                    |row| {
-                                        Ok((
-                                            row.get::<_, f64>(0).unwrap(),
-                                            row.get::<_, f64>(1).unwrap(),
-                                        ))
-                                    },
-                                )
-                                .optional()
-                                .unwrap()
-                                .unwrap_or((0.0, 350.0 / 173.7178));
-
-                            let opponent_rating: GlickoRating = Glicko2Rating {
-                                value: opponent_value,
-                                deviation: opponent_deviation,
-                                volatility: 0.0,
-                            }
-                            .into();
-
-                            let (
-                                expected_outcome_min,
-                                expected_outcome,
-                                expected_outcome_max,
-                                expected_outcome_evaluation,
-                            ) = get_expected_outcomes(
-                                value,
-                                deviation,
-                                opponent_value,
-                                opponent_deviation,
-                            );
-
-                            if let Some(set) = recent_games.last_mut().filter(|set| {
-                                set.opponent_id == format!("{:X}", opponent_id)
-                                    && set.opponent_character
-                                        == website::CHAR_NAMES[opponent_character as usize].1
-                                    && group_games
-                            }) {
-                                set.timestamp = format!(
-                                    "{}",
-                                    NaiveDateTime::from_timestamp(timestamp, 0)
-                                        .format("%Y-%m-%d %H:%M")
-                                );
-                                set.own_rating_value = own_rating.value.round();
-                                set.own_rating_deviation = (own_rating.deviation * 2.0).round();
-                                set.opponent_rating_value = opponent_rating.value.round();
-                                set.opponent_rating_deviation =
-                                    (opponent_rating.deviation * 2.0).round();
-
-                                set.expected_outcome = expected_outcome;
-                                set.expected_outcome_evaluation = expected_outcome_evaluation;
-                                set.expected_outcome_min = expected_outcome_min;
-                                set.expected_outcome_max = set.expected_outcome_max;
-
-                                match winner {
-                                    1 | 4 => set.result_wins += 1,
-                                    2 | 3 => set.result_losses += 1,
-                                    _ => panic!("Bad winner"),
-                                }
-
-                                set.result_percent = ((set.result_wins as f64
-                                    / (set.result_wins + set.result_losses) as f64)
-                                    * 100.0)
-                                    .round();
-                            } else {
-                                recent_games.push(PlayerSet {
-                                    timestamp: format!(
-                                        "{}",
-                                        NaiveDateTime::from_timestamp(timestamp, 0)
-                                            .format("%Y-%m-%d %H:%M")
-                                    ),
-                                    own_rating_value: own_rating.value.round(),
-                                    own_rating_deviation: (own_rating.deviation * 2.0).round(),
-                                    floor: match floor {
-                                        99 => format!("Celestial"),
-                                        n => format!("Floor {}", n),
-                                    },
-                                    opponent_name: opponent_name,
-                                    opponent_vip,
-                                    opponent_cheater,
-                                    opponent_id: format!("{:X}", opponent_id),
-                                    opponent_character: website::CHAR_NAMES
-                                        [opponent_character as usize]
-                                        .1
-                                        .to_owned(),
-                                    opponent_character_short: website::CHAR_NAMES
-                                        [opponent_character as usize]
-                                        .0
-                                        .to_owned(),
-                                    opponent_rating_value: opponent_rating.value.round(),
-                                    opponent_rating_deviation: (opponent_rating.deviation * 2.0)
-                                        .round(),
-                                    expected_outcome,
-                                    expected_outcome_evaluation,
-                                    expected_outcome_min,
-                                    expected_outcome_max,
-                                    result_wins: match winner {
-                                        1 | 4 => 1,
-                                        _ => 0,
-                                    },
-                                    result_losses: match winner {
-                                        2 | 3 => 1,
-                                        _ => 0,
-                                    },
-                                    result_percent: match winner {
-                                        1 | 4 => 100.0,
-                                        _ => 0.0,
-                                    },
-                                });
-                            }
-                        }
-
-                        recent_games
-                    };
-
-                    let matchups = {
-                        let mut stmt = conn
-                            .prepare(
-                                "SELECT
-                                    opp_char_id,
-                                    wins_real,
-                                    wins_adjusted,
-                                    losses_real,
-                                    losses_adjusted
-                                FROM player_matchups
-                                WHERE id = ?
-                                    AND char_id = ?
-                                ORDER BY wins_real DESC",
-                            )
-                            .unwrap();
-
-                        let mut rows = stmt.query(params![id, char_id]).unwrap();
-                        let mut matchups = Vec::<PlayerMatchup>::new();
-                        while let Some(row) = rows.next().unwrap() {
-                            let opp_char_id: usize = row.get(0).unwrap();
-                            let wins_real: f64 = row.get(1).unwrap();
-                            let wins_adjusted: f64 = row.get(2).unwrap();
-                            let losses_real: f64 = row.get(3).unwrap();
-                            let losses_adjusted: f64 = row.get(4).unwrap();
-                            matchups.push(PlayerMatchup {
-                                character: website::CHAR_NAMES[opp_char_id].1.to_owned(),
-                                game_count: (wins_real + losses_real) as i32,
-                                win_rate_real: (wins_real / (wins_real + losses_real) * 100.0)
-                                    .round(),
-                                win_rate_adjusted: (wins_adjusted
-                                    / (wins_adjusted + losses_adjusted)
-                                    * 100.0)
-                                    .round(),
-                            });
-                        }
-
-                        matchups.sort_by_key(|m| -(m.win_rate_adjusted as i32));
-
-                        matchups
-                    };
-
-                    PlayerCharacterData {
-                        character_name,
-                        game_count: wins + losses,
-                        win_rate: wins as f64 / (wins + losses) as f64,
-                        rating_value: (value * 173.7178 + 1500.0).round(),
-                        rating_deviation: (deviation * 173.7178 * 2.0).round(),
-                        history,
-                        recent_games,
-                        matchups,
-                        character_rank,
-                        global_rank,
-                    }
-                }
-            };
+            let character_data = get_player_character_data(conn, id, char_id, group_games, game_count);
 
             Some(PlayerDataChar {
                 id: format!("{:X}", id),
@@ -1002,11 +504,7 @@ pub async fn get_player_data_char(
                 vip_status,
                 cheater_status,
                 other_characters,
-                other_names: if other_names.is_empty() {
-                    None
-                } else {
-                    Some(other_names)
-                },
+                other_names,
                 data: character_data,
             })
         } else {
@@ -1014,6 +512,514 @@ pub async fn get_player_data_char(
         }
     })
     .await
+}
+
+fn get_player_other_names(conn: &Connection, id: i64, name: &str) -> Option<Vec<String>> {
+    let mut stmt = conn
+        .prepare("SELECT name FROM player_names WHERE id=?")
+        .unwrap();
+    let mut rows = stmt.query(params![id]).unwrap();
+    let mut other_names = Vec::new();
+    while let Some(row) = rows.next().unwrap() {
+        let other_name: String = row.get(0).unwrap();
+        if other_name != name && !other_names.contains(&other_name) {
+            other_names.push(other_name);
+        }
+    }
+
+    if other_names.is_empty() {
+        None
+    } else {
+        Some(other_names)
+    }
+}
+
+fn get_player_other_characters(conn: &Connection, id: i64) -> Vec<OtherPlayerCharacter> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT
+            char_id, wins, losses, value, deviation
+            FROM player_ratings
+            WHERE id=?",
+        )
+        .unwrap();
+
+    let mut other_characters = Vec::new();
+
+    let mut rows = stmt.query(params![id]).unwrap();
+
+    while let Some(row) = rows.next().unwrap() {
+        let char_id: usize = row.get(0).unwrap();
+        let game_count: i32 =
+            row.get::<_, i32>(1).unwrap() + row.get::<_, i32>(2).unwrap();
+        let rating: GlickoRating = Glicko2Rating {
+            value: row.get(3).unwrap(),
+            deviation: row.get(4).unwrap(),
+            volatility: 0.0,
+        }
+        .into();
+
+        let character_name = website::CHAR_NAMES[char_id].1.to_owned();
+        let character_shortname = website::CHAR_NAMES[char_id].0.to_owned();
+        other_characters.push(OtherPlayerCharacter {
+            character_name,
+            character_shortname,
+            game_count,
+            rating_value: rating.value.round(),
+            rating_deviation: (rating.deviation * 2.0).round(),
+        });
+    }
+
+    other_characters
+}
+
+fn get_player_character_data(conn: &Connection, id: i64, char_id: i64, group_games: bool, game_count: i64) -> PlayerCharacterData {
+    let (wins, losses, value, deviation, global_rank, character_rank) = conn
+        .query_row(
+            "SELECT wins, losses, value, deviation, global_rank, character_rank
+            FROM player_ratings
+            LEFT JOIN ranking_global ON
+                ranking_global.id = player_ratings.id AND
+                ranking_global.char_id = player_ratings.char_id
+            LEFT JOIN ranking_character ON
+                ranking_character.id = player_ratings.id AND
+                ranking_character.char_id = player_ratings.char_id
+            WHERE player_ratings.id=? AND player_ratings.char_id=?",
+            params![id, char_id],
+            |row| {
+                Ok((
+                    row.get::<_, i32>(0).unwrap(),
+                    row.get::<_, i32>(1).unwrap(),
+                    row.get::<_, f64>(2).unwrap(),
+                    row.get::<_, f64>(3).unwrap(),
+                    row.get::<_, Option<i32>>(4).unwrap(),
+                    row.get::<_, Option<i32>>(5).unwrap(),
+                ))
+            },
+        )
+        .unwrap();
+    {
+        let character_name = website::CHAR_NAMES[char_id as usize].1.to_owned();
+
+        let history = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT
+                        timestamp,
+                        value_a AS own_value,
+                        deviation_a AS own_deviation,
+                        game_floor,
+                        name_b AS opponent_name,
+                        id_b AS opponent_id,
+                        char_b AS opponent_character,
+                        value_b AS opponent_value,
+                        deviation_b AS opponent_deviation,
+                        winner,
+                        vip_status,
+                        cheater_status
+                    FROM games NATURAL JOIN game_ratings
+                    LEFT JOIN vip_status ON vip_status.id = games.id_b
+                    LEFT JOIN cheater_status ON cheater_status.id = games.id_b
+                    WHERE games.id_a= :id AND games.char_a = :char_id
+
+                    UNION
+
+                    SELECT
+                        timestamp,
+                        value_b AS own_value,
+                        deviation_b AS own_deviation,
+                        game_floor,
+                        name_a AS opponent_name,
+                        id_a AS opponent_id,
+                        char_a AS opponent_character,
+                        value_a AS opponent_value,
+                        deviation_a AS opponent_deviation,
+                        winner + 2  as winner,
+                        vip_status,
+                        cheater_status
+                    FROM games NATURAL JOIN game_ratings
+                    LEFT JOIN vip_status ON vip_status.id = games.id_a
+                    LEFT JOIN cheater_status ON cheater_status.id = games.id_a
+                    WHERE games.id_b = :id AND games.char_b = :char_id
+
+                    ORDER BY timestamp DESC LIMIT :game_count",
+                )
+                .unwrap();
+
+            let mut rows = stmt
+                .query(named_params! {
+                    ":id" : id,
+                    ":char_id": char_id,
+                    ":game_count":game_count,
+                })
+                .unwrap();
+            let mut history = Vec::<PlayerSet>::new();
+            while let Some(row) = rows.next().unwrap() {
+                let timestamp: i64 = row.get("timestamp").unwrap();
+                let own_value: f64 = row.get("own_value").unwrap();
+                let own_deviation: f64 = row.get("own_deviation").unwrap();
+                let floor: i64 = row.get("game_floor").unwrap();
+                let opponent_name: String = row.get("opponent_name").unwrap();
+                let opponent_id: i64 = row.get("opponent_id").unwrap();
+                let opponent_character: i64 = row.get("opponent_character").unwrap();
+                let opponent_value: f64 = row.get("opponent_value").unwrap();
+                let opponent_deviation: f64 = row.get("opponent_deviation").unwrap();
+                let winner: i64 = row.get("winner").unwrap();
+                let opponent_vip: Option<String> = row.get("vip_status").unwrap();
+                let opponent_cheater: Option<String> =
+                    row.get("cheater_status").unwrap();
+
+                let own_rating: GlickoRating = Glicko2Rating {
+                    value: own_value,
+                    deviation: own_deviation,
+                    volatility: 0.0,
+                }
+                .into();
+
+                let opponent_rating: GlickoRating = Glicko2Rating {
+                    value: opponent_value,
+                    deviation: opponent_deviation,
+                    volatility: 0.0,
+                }
+                .into();
+
+                let (
+                    expected_outcome_min,
+                    expected_outcome,
+                    expected_outcome_max,
+                    expected_outcome_evaluation,
+                ) = get_expected_outcomes(
+                    own_value,
+                    own_deviation,
+                    opponent_value,
+                    opponent_deviation,
+                );
+
+                if let Some(set) = history.last_mut().filter(|set| {
+                    set.opponent_id == format!("{:X}", opponent_id)
+                        && set.opponent_character
+                            == website::CHAR_NAMES[opponent_character as usize].1
+                        && group_games
+                }) {
+                    set.timestamp = format!(
+                        "{}",
+                        NaiveDateTime::from_timestamp(timestamp, 0)
+                            .format("%Y-%m-%d %H:%M")
+                    );
+                    set.own_rating_value = own_rating.value.round();
+                    set.own_rating_deviation = (own_rating.deviation * 2.0).round();
+                    set.opponent_rating_value = opponent_rating.value.round();
+                    set.opponent_rating_deviation =
+                        (opponent_rating.deviation * 2.0).round();
+
+                    set.expected_outcome = expected_outcome;
+                    set.expected_outcome_evaluation = expected_outcome_evaluation;
+                    set.expected_outcome_min = expected_outcome_min;
+                    set.expected_outcome_max = set.expected_outcome_max;
+
+                    match winner {
+                        1 | 4 => set.result_wins += 1,
+                        2 | 3 => set.result_losses += 1,
+                        _ => panic!("Bad winner"),
+                    }
+
+                    set.result_percent = ((set.result_wins as f64
+                        / (set.result_wins + set.result_losses) as f64)
+                        * 100.0)
+                        .round();
+                } else {
+                    history.push(PlayerSet {
+                        timestamp: format!(
+                            "{}",
+                            NaiveDateTime::from_timestamp(timestamp, 0)
+                                .format("%Y-%m-%d %H:%M")
+                        ),
+                        own_rating_value: own_rating.value.round(),
+                        own_rating_deviation: (own_rating.deviation * 2.0).round(),
+                        floor: match floor {
+                            99 => format!("Celestial"),
+                            n => format!("Floor {}", n),
+                        },
+                        opponent_name: opponent_name,
+                        opponent_vip,
+                        opponent_cheater,
+                        opponent_id: format!("{:X}", opponent_id),
+                        opponent_character: website::CHAR_NAMES
+                            [opponent_character as usize]
+                            .1
+                            .to_owned(),
+                        opponent_character_short: website::CHAR_NAMES
+                            [opponent_character as usize]
+                            .0
+                            .to_owned(),
+                        opponent_rating_value: opponent_rating.value.round(),
+                        opponent_rating_deviation: (opponent_rating.deviation * 2.0)
+                            .round(),
+                        expected_outcome,
+                        expected_outcome_evaluation,
+                        expected_outcome_min,
+                        expected_outcome_max,
+                        result_wins: match winner {
+                            1 | 4 => 1,
+                            _ => 0,
+                        },
+                        result_losses: match winner {
+                            2 | 3 => 1,
+                            _ => 0,
+                        },
+                        result_percent: match winner {
+                            1 | 4 => 100.0,
+                            _ => 0.0,
+                        },
+                    });
+                }
+            }
+
+            history
+        };
+
+        let recent_games = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT
+                        games.timestamp AS timestamp,
+                        game_floor,
+                        name_b AS opponent_name,
+                        games.id_b AS opponent_id,
+                        games.char_b AS opponent_character,
+                        winner,
+                        vip_status,
+                        cheater_status
+                    FROM games LEFT JOIN game_ratings
+                    ON games.id_a = game_ratings.id_a
+                        AND games.id_b = game_ratings.id_b
+                        AND games.timestamp = game_ratings.timestamp
+                    LEFT JOIN vip_status ON vip_status.id = games.id_b
+                    LEFT JOIN cheater_status ON cheater_status.id = games.id_b
+                    WHERE games.id_a= :id
+                        AND games.char_a = :char_id
+                        AND game_ratings.id_a IS NULL
+
+                    UNION
+
+                    SELECT
+                        games.timestamp AS timestamp,
+                        game_floor,
+                        name_a AS opponent_name,
+                        games.id_a AS opponent_id,
+                        games.char_a AS opponent_character,
+                        winner + 2  as winner,
+                        vip_status,
+                        cheater_status
+                    FROM games LEFT JOIN game_ratings
+                    ON games.id_a = game_ratings.id_a
+                        AND games.id_b = game_ratings.id_b
+                        AND games.timestamp = game_ratings.timestamp
+                    LEFT JOIN vip_status ON vip_status.id = games.id_a
+                    LEFT JOIN cheater_status ON cheater_status.id = games.id_a
+                    WHERE games.id_b= :id
+                        AND games.char_b = :char_id
+                        AND game_ratings.id_a IS NULL
+
+                    ORDER BY games.timestamp DESC",
+                )
+                .unwrap();
+
+            let mut rows = stmt
+                .query(named_params! {":id" : id, ":char_id": char_id})
+                .unwrap();
+            let mut recent_games = Vec::<PlayerSet>::new();
+            while let Some(row) = rows.next().unwrap() {
+                let timestamp: i64 = row.get("timestamp").unwrap();
+                let floor: i64 = row.get("game_floor").unwrap();
+                let opponent_name: String = row.get("opponent_name").unwrap();
+                let opponent_id: i64 = row.get("opponent_id").unwrap();
+                let opponent_character: i64 = row.get("opponent_character").unwrap();
+                let winner: i64 = row.get("winner").unwrap();
+                let opponent_vip: Option<String> = row.get("vip_status").unwrap();
+                let opponent_cheater: Option<String> =
+                    row.get("cheater_status").unwrap();
+
+                let own_rating: GlickoRating = Glicko2Rating {
+                    value: value,
+                    deviation: deviation,
+                    volatility: 0.0,
+                }
+                .into();
+
+                let (opponent_value, opponent_deviation) = conn
+                    .query_row(
+                        "SELECT value, deviation
+                    FROM player_ratings
+                    WHERE id=? AND char_id=?",
+                        params![opponent_id, opponent_character],
+                        |row| {
+                            Ok((
+                                row.get::<_, f64>(0).unwrap(),
+                                row.get::<_, f64>(1).unwrap(),
+                            ))
+                        },
+                    )
+                    .optional()
+                    .unwrap()
+                    .unwrap_or((0.0, 350.0 / 173.7178));
+
+                let opponent_rating: GlickoRating = Glicko2Rating {
+                    value: opponent_value,
+                    deviation: opponent_deviation,
+                    volatility: 0.0,
+                }
+                .into();
+
+                let (
+                    expected_outcome_min,
+                    expected_outcome,
+                    expected_outcome_max,
+                    expected_outcome_evaluation,
+                ) = get_expected_outcomes(
+                    value,
+                    deviation,
+                    opponent_value,
+                    opponent_deviation,
+                );
+
+                if let Some(set) = recent_games.last_mut().filter(|set| {
+                    set.opponent_id == format!("{:X}", opponent_id)
+                        && set.opponent_character
+                            == website::CHAR_NAMES[opponent_character as usize].1
+                        && group_games
+                }) {
+                    set.timestamp = format!(
+                        "{}",
+                        NaiveDateTime::from_timestamp(timestamp, 0)
+                            .format("%Y-%m-%d %H:%M")
+                    );
+                    set.own_rating_value = own_rating.value.round();
+                    set.own_rating_deviation = (own_rating.deviation * 2.0).round();
+                    set.opponent_rating_value = opponent_rating.value.round();
+                    set.opponent_rating_deviation =
+                        (opponent_rating.deviation * 2.0).round();
+
+                    set.expected_outcome = expected_outcome;
+                    set.expected_outcome_evaluation = expected_outcome_evaluation;
+                    set.expected_outcome_min = expected_outcome_min;
+                    set.expected_outcome_max = set.expected_outcome_max;
+
+                    match winner {
+                        1 | 4 => set.result_wins += 1,
+                        2 | 3 => set.result_losses += 1,
+                        _ => panic!("Bad winner"),
+                    }
+
+                    set.result_percent = ((set.result_wins as f64
+                        / (set.result_wins + set.result_losses) as f64)
+                        * 100.0)
+                        .round();
+                } else {
+                    recent_games.push(PlayerSet {
+                        timestamp: format!(
+                            "{}",
+                            NaiveDateTime::from_timestamp(timestamp, 0)
+                                .format("%Y-%m-%d %H:%M")
+                        ),
+                        own_rating_value: own_rating.value.round(),
+                        own_rating_deviation: (own_rating.deviation * 2.0).round(),
+                        floor: match floor {
+                            99 => format!("Celestial"),
+                            n => format!("Floor {}", n),
+                        },
+                        opponent_name: opponent_name,
+                        opponent_vip,
+                        opponent_cheater,
+                        opponent_id: format!("{:X}", opponent_id),
+                        opponent_character: website::CHAR_NAMES
+                            [opponent_character as usize]
+                            .1
+                            .to_owned(),
+                        opponent_character_short: website::CHAR_NAMES
+                            [opponent_character as usize]
+                            .0
+                            .to_owned(),
+                        opponent_rating_value: opponent_rating.value.round(),
+                        opponent_rating_deviation: (opponent_rating.deviation * 2.0)
+                            .round(),
+                        expected_outcome,
+                        expected_outcome_evaluation,
+                        expected_outcome_min,
+                        expected_outcome_max,
+                        result_wins: match winner {
+                            1 | 4 => 1,
+                            _ => 0,
+                        },
+                        result_losses: match winner {
+                            2 | 3 => 1,
+                            _ => 0,
+                        },
+                        result_percent: match winner {
+                            1 | 4 => 100.0,
+                            _ => 0.0,
+                        },
+                    });
+                }
+            }
+
+            recent_games
+        };
+
+        let matchups = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT
+                        opp_char_id,
+                        wins_real,
+                        wins_adjusted,
+                        losses_real,
+                        losses_adjusted
+                    FROM player_matchups
+                    WHERE id = ?
+                        AND char_id = ?
+                    ORDER BY wins_real DESC",
+                )
+                .unwrap();
+
+            let mut rows = stmt.query(params![id, char_id]).unwrap();
+            let mut matchups = Vec::<PlayerMatchup>::new();
+            while let Some(row) = rows.next().unwrap() {
+                let opp_char_id: usize = row.get(0).unwrap();
+                let wins_real: f64 = row.get(1).unwrap();
+                let wins_adjusted: f64 = row.get(2).unwrap();
+                let losses_real: f64 = row.get(3).unwrap();
+                let losses_adjusted: f64 = row.get(4).unwrap();
+                matchups.push(PlayerMatchup {
+                    character: website::CHAR_NAMES[opp_char_id].1.to_owned(),
+                    game_count: (wins_real + losses_real) as i32,
+                    win_rate_real: (wins_real / (wins_real + losses_real) * 100.0)
+                        .round(),
+                    win_rate_adjusted: (wins_adjusted
+                        / (wins_adjusted + losses_adjusted)
+                        * 100.0)
+                        .round(),
+                });
+            }
+
+            matchups.sort_by_key(|m| -(m.win_rate_adjusted as i32));
+
+            matchups
+        };
+
+        PlayerCharacterData {
+            character_name,
+            game_count: wins + losses,
+            win_rate: wins as f64 / (wins + losses) as f64,
+            rating_value: (value * 173.7178 + 1500.0).round(),
+            rating_deviation: (deviation * 173.7178 * 2.0).round(),
+            history,
+            recent_games,
+            matchups,
+            character_rank,
+            global_rank,
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -1731,8 +1737,8 @@ pub async fn rating_experience(
                 .prepare(
                     "SELECT value_a, value_b
                     FROM game_ratings
-                    WHERE deviation_a < ? AND deviation_b < ? AND 
-                        ((value_a > ? AND value_a < ?) 
+                    WHERE deviation_a < ? AND deviation_b < ? AND
+                        ((value_a > ? AND value_a < ?)
                         OR
                         (value_b > ? AND value_b < ?))",
                 )

--- a/src/api.rs
+++ b/src/api.rs
@@ -516,7 +516,7 @@ pub async fn get_player_data_char(
 
 fn get_player_other_names(conn: &Connection, id: i64, name: &str) -> Option<Vec<String>> {
     let mut stmt = conn
-        .prepare("SELECT name FROM player_names WHERE id=?")
+        .prepare_cached("SELECT name FROM player_names WHERE id=?")
         .unwrap();
     let mut rows = stmt.query(params![id]).unwrap();
     let mut other_names = Vec::new();
@@ -536,7 +536,7 @@ fn get_player_other_names(conn: &Connection, id: i64, name: &str) -> Option<Vec<
 
 fn get_player_other_characters(conn: &Connection, id: i64) -> Vec<OtherPlayerCharacter> {
     let mut stmt = conn
-        .prepare(
+        .prepare_cached(
             "SELECT
             char_id, wins, losses, value, deviation
             FROM player_ratings
@@ -603,7 +603,7 @@ fn get_player_character_data(conn: &Connection, id: i64, char_id: i64, group_gam
 
         let history = {
             let mut stmt = conn
-                .prepare(
+                .prepare_cached(
                     "SELECT
                         timestamp,
                         value_a AS own_value,
@@ -695,7 +695,7 @@ fn get_player_character_data(conn: &Connection, id: i64, char_id: i64, group_gam
 
         let recent_games = {
             let mut stmt = conn
-                .prepare(
+                .prepare_cached(
                     "SELECT
                         games.timestamp AS timestamp,
                         game_floor,
@@ -799,7 +799,7 @@ fn get_player_character_data(conn: &Connection, id: i64, char_id: i64, group_gam
 
         let matchups = {
             let mut stmt = conn
-                .prepare(
+                .prepare_cached(
                     "SELECT
                         opp_char_id,
                         wins_real,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,8 @@
+#[macro_use]
+extern crate rocket;
+#[macro_use]
+extern crate log;
+
+mod api;
+pub mod rater;
+pub mod website;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,11 @@
 #![feature(proc_macro_hygiene, decl_macro)]
 
-#[macro_use]
-extern crate rocket;
-#[macro_use]
-extern crate log;
 use simplelog::*;
 use std::{fs::File, ops::Deref};
 use tokio::try_join;
 
-mod api;
-mod rater;
-mod website;
+
+use rating_update::{rater, website};
 
 fn init_logging() {
     if cfg!(debug_assertions) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,10 @@ async fn main() {
             println!("Unrecognized argument: {}", x);
         }
         None => {
-            try_join!(tokio::spawn(website::run()), tokio::spawn(rater::run())).unwrap();
+            if let Err(err) = try_join!(async { tokio::spawn(website::run()).await?; Ok(()) }, rater::run()) {
+                eprintln!("{:?}", err);
+                std::process::exit(1);
+            }
         }
     }
 }

--- a/src/rater.rs
+++ b/src/rater.rs
@@ -15,7 +15,7 @@ use crate::website;
 const SYS_CONSTANT: f64 = 0.8;
 pub const MAX_DEVIATION: f64 = 75.0 / 173.7178;
 pub const HIGH_RATING: f64 = (1800.0 - 1500.0) / 173.7178;
-const DB_NAME: &str = "ratings.sqlite";
+pub const DB_NAME: &str = "ratings.sqlite";
 
 const CHAR_COUNT: usize = website::CHAR_NAMES.len();
 pub const POP_RATING_BRACKETS: usize = 11;

--- a/src/website.rs
+++ b/src/website.rs
@@ -1,5 +1,4 @@
-use crate::{api, rater};
-use chrono::Utc;
+use crate::api;
 use rocket::{
     fs::NamedFile,
     http::{hyper::header::CACHE_CONTROL, Header},


### PR DESCRIPTION
Started looking into if there was a way to improve performance of the `/player` page. There are a few different changes here as I first had to figure out to setup a database, followed by some refactoring to make the code and profiler data easier to understand which finally resulted in two improvements.

First I added caching to the prepared statements (I only added it for the API under `/player`, but other `prepare` calls should perhaps also be cached). This gave a small improvement of a couple of percent.

Second I added two new indices to the `games` table which significantly improves performance (in my benchmark at least). There does not appear to be any database migration in place so these
needs to be manually applied to the real database.

```
load_player             time:   [109.13 ms 112.87 ms 116.59 ms]
                        change: [-63.773% -38.519% -4.7021%] (p = 0.20 > 0.05)
```

The PR should be possible to review commit by commit but I could perhaps split it up if that would be easier.