### PR TITLE
bind to localhost only & nginx config file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ cargo run pull #Pulls data, without updating anything
 You can find more in `main.rs`
 
 
-Once the database is setup you can start a local server that is accessible on `localhost`
+Once the database is setup you can start a local server that is accessible on `localhost:8085`
 with `cargo run`. By default the server will continuously pull down new replays and update the rankings. If you do not
 want this behaviour you may run `cargo run -- nothoughts` instead to only start the website.

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,6 +1,6 @@
 [default]
-address = "0.0.0.0"
-port = 80
+address = "127.0.0.1"
+port = 8085
 
 [global.databases]
 ratings = { url = "ratings.sqlite" }

--- a/nginx-example.conf
+++ b/nginx-example.conf
@@ -1,0 +1,11 @@
+server {
+	server_name ratingupdate.info;
+	# access_log /var/log/nginx/ratingupdate.log
+	location / {
+		proxy_pass http://127.0.0.1:8085;
+	}
+
+	location ~ /\.well-known/acme-challenge {
+		root /var/lib/letsencrypt/;
+	}
+}


### PR DESCRIPTION
i changed the port to 8085 (tho you could make it whatever you want afterwards) and made a config file for nginx to reverse proxy and allow certbot to give ssl certificates for https

make sure nginx and certbot are installed (you might need to find a special certbot-nginx plugin in the package manager for them to work together

move nginx-example.conf to ``/etc/nginx/sites-enabled/`` (rename it if you want)
run ``nginx -t`` to check for errors then restart nginx ``systemctl restart nginx`` (or however you restart services)
then run ``certbot --nginx`` and follow the steps and it should automatically give you the certificates
optionally put ``cerbot renew`` in a cronjob or just run it normally to renew certs when they need it