### PR TITLE
Bump `ahash` to v0.7.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",


### PR DESCRIPTION
Resolves a weird build regression with v0.7.6; more info in tkaitchuck/aHash#200.
```
❯ RUST_LOG=info cargo +nightly run --release -- nothoughts  
   Compiling ahash v0.7.6
error[E0635]: unknown feature `stdsimd`
  --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ahash-0.7.6/src/lib.rs:33:42
   |
33 | #![cfg_attr(feature = "stdsimd", feature(stdsimd))]
   |                                          ^^^^^^^
```